### PR TITLE
Fix Changesets v2 publish input

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -37,6 +37,6 @@ jobs:
         uses: changesets/action@v2.1.0
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
+          publish-script: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow still passes the Changesets v1 `publish` input after upgrading to `changesets/action@v2.1.0`. Changesets v2 rejects that input before it can create a release pull request or publish to npm.

Use the renamed `publish-script` input while keeping `npm run release` as the command. This fixes [Release run 31698067038](https://github.com/ota-meshi/eslint-json-compat-utils/actions/runs/31698067038).
